### PR TITLE
uncast numpy objects

### DIFF
--- a/simple_spearmint/simple_spearmint.py
+++ b/simple_spearmint/simple_spearmint.py
@@ -187,7 +187,8 @@ class SimpleSpearmint(object):
                     low=spec['min'], high=spec['max']))
             # In enum, sample from options using choice
             elif spec['type'] == 'enum':
-                suggestion[name] = str(np.random.choice(spec['options']))
+                suggestion_index = np.random.choice(len(spec['options']))
+                suggestion[name] = spec['options'][suggestion_index]
             # Raise an error if another type was specified
             else:
                 raise ValueError('Parameter type {} is not valid.'.format(

--- a/simple_spearmint/simple_spearmint.py
+++ b/simple_spearmint/simple_spearmint.py
@@ -179,15 +179,15 @@ class SimpleSpearmint(object):
         for name, spec in self.parameter_space.items():
             # Sample floats from np.random.uniform
             if spec['type'] == 'float':
-                suggestion[name] = np.random.uniform(
-                    low=spec['min'], high=spec['max'])
+                suggestion[name] = float(np.random.uniform(
+                    low=spec['min'], high=spec['max']))
             # Sample ints from np.random.random_integers
             elif spec['type'] == 'int':
-                suggestion[name] = np.random.random_integers(
-                    low=spec['min'], high=spec['max'])
+                suggestion[name] = int(np.random.random_integers(
+                    low=spec['min'], high=spec['max']))
             # In enum, sample from options using choice
             elif spec['type'] == 'enum':
-                suggestion[name] = np.random.choice(spec['options'])
+                suggestion[name] = str(np.random.choice(spec['options']))
             # Raise an error if another type was specified
             else:
                 raise ValueError('Parameter type {} is not valid.'.format(


### PR DESCRIPTION
When these objects are non-native, they cause problems down the road, e.g.
dumping them to a yaml file.
